### PR TITLE
Fixes #1: Remove deprecated.txt

### DIFF
--- a/lang/en/deprecated.txt
+++ b/lang/en/deprecated.txt
@@ -1,1 +1,0 @@
- assigngroup_confirm.mod_groupselect


### PR DESCRIPTION
The string has already been removed and this causes unit tests failures.