### PR TITLE
Delete deprecated.txt

### DIFF
--- a/lang/en/deprecated.txt
+++ b/lang/en/deprecated.txt
@@ -1,1 +1,0 @@
- assigngroup_confirm.mod_groupselect


### PR DESCRIPTION
The corresponding deprecated strings have already been removed, this causes unit test failures.